### PR TITLE
Update to v0.8.60.

### DIFF
--- a/u2f-chrome-extension/devicefactoryregistry.js
+++ b/u2f-chrome-extension/devicefactoryregistry.js
@@ -13,13 +13,18 @@
 /**
  * @param {!GnubbyFactory} gnubbyFactory A Gnubby factory.
  * @param {!CountdownFactory} countdownFactory A countdown timer factory.
+ * @param {!IndividualAttestation} individualAttestation An individual
+ *     attestation implementation.
  * @constructor
  */
-function DeviceFactoryRegistry(gnubbyFactory, countdownFactory) {
+function DeviceFactoryRegistry(gnubbyFactory, countdownFactory,
+    individualAttestation) {
   /** @private {!GnubbyFactory} */
   this.gnubbyFactory_ = gnubbyFactory;
   /** @private {!CountdownFactory} */
   this.countdownFactory_ = countdownFactory;
+  /** @private {!IndividualAttestation} */
+  this.individualAttestation_ = individualAttestation;
 }
 
 /** @return {!GnubbyFactory} A Gnubby factory. */
@@ -30,4 +35,10 @@ DeviceFactoryRegistry.prototype.getGnubbyFactory = function() {
 /** @return {!CountdownFactory} A countdown factory. */
 DeviceFactoryRegistry.prototype.getCountdownFactory = function() {
   return this.countdownFactory_;
+};
+
+/** @return {!IndividualAttestation} An individual attestation implementation.
+ */
+DeviceFactoryRegistry.prototype.getIndividualAttestation = function() {
+  return this.individualAttestation_;
 };

--- a/u2f-chrome-extension/etld.js
+++ b/u2f-chrome-extension/etld.js
@@ -154,8 +154,8 @@ EffectiveTldFetcher.prototype.getEffectiveTldsFromText_ = function(text) {
     }
     // For now, ignore non-alpha first characters, e.g. *.mz or !teledata.mz,
     // because interpreting them correctly is more difficult: wildcard matching
-    // rules aren't defined to my knowledge, and the conflicting rules imply
-    // precedence within the origins list.
+    // rules imply precedence within the origins list. See the rule definition
+    // at https://publicsuffix.org/list/
     // TODO: This test also doesn't match non-alpha starting
     // characters. Implement for these cases too.
     if (!/^[a-zA-Z]/.test(line)) {

--- a/u2f-chrome-extension/etldorigincheck.js
+++ b/u2f-chrome-extension/etldorigincheck.js
@@ -1,0 +1,88 @@
+// Copyright 2014 Google Inc. All rights reserved
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+/**
+ * @fileoverview Implements a check whether an origin is allowed to assert an
+ * app id based on whether they share the same effective TLD + 1.
+ *
+ */
+'use strict';
+
+/**
+ * Implements half of the app id policy: whether an origin is allowed to claim
+ * an app id. For checking whether the app id also lists the origin,
+ * @see AppIdChecker.
+ * @implements OriginChecker
+ * @constructor
+ */
+function EtldOriginChecker() {
+  // The instance of this class is managed by FactoryRegistry, which also
+  // manages a TextFetcher on which EffectiveTldFetcher depends. Thus, we must
+  // initialize the EffectiveTldFetcher lazily (see getFetcher_).
+  /** @private {EffectiveTldFetcher} */
+  this.etldFetcher_ = null;
+}
+
+/**
+ * Gets an EffectiveTldFetcher instnace, creating one if necessary.
+ * @return {!EffectiveTldFetcher}
+ * @private
+ */
+EtldOriginChecker.prototype.getFetcher_ = function() {
+  if (!this.etldFetcher_) {
+    var fetcher = FACTORY_REGISTRY.getTextFetcher();
+    this.etldFetcher_ = new EffectiveTldFetcher(fetcher, true);
+  }
+  return this.etldFetcher_;
+};
+
+/**
+ * Checks whether the origin is allowed to claim the app ids.
+ * @param {string} origin The origin claiming the app id.
+ * @param {!Array.<string>} appIds The app ids being claimed.
+ * @return {Promise.<boolean>} A promise for the result of the check.
+ */
+EtldOriginChecker.prototype.canClaimAppIds = function(origin, appIds) {
+  // First make sure we know the origin's eTLD + 1, to know whether the origin
+  // can assert the app ids.
+  var p = this.getFetcher_().getEffectiveTldPlusOne(origin);
+  var self = this;
+  return p.then(function(originEtldPlusOne) {
+    if (!originEtldPlusOne)
+      return Promise.resolve(false);
+    var appIdChecks = appIds.map(
+        self.checkAppId_.bind(self, origin, originEtldPlusOne));
+    return Promise.all(appIdChecks).then(function(results) {
+      return results.every(function(result) {
+        return result;
+      });
+    });
+  });
+};
+
+/**
+ * Checks if a single appId can be asserted by the given origin.
+ * @param {string} origin The origin.
+ * @param {string} originEtldPlusOne The origin's etld + 1.
+ * @param {string} appId The appId to check
+ * @return {Promise.<boolean>} A promise for the result of the check
+ * @private
+ */
+EtldOriginChecker.prototype.checkAppId_ =
+    function(origin, originEtldPlusOne, appId) {
+  if (appId == origin) {
+    // Trivially allowed
+    return Promise.resolve(true);
+  }
+  var appIdOrigin = getOriginFromUrl(appId);
+  if (!appIdOrigin)
+    return Promise.resolve(false);
+  var appIdOriginString = /** @type {string} */ (appIdOrigin);
+  var p = this.getFetcher_().getEffectiveTldPlusOne(appIdOriginString);
+  return p.then(function(appIdEtldPlusOne) {
+    return originEtldPlusOne == appIdEtldPlusOne;
+  });
+};

--- a/u2f-chrome-extension/factoryregistry.js
+++ b/u2f-chrome-extension/factoryregistry.js
@@ -12,14 +12,17 @@
 
 /**
  * @param {!CountdownFactory} countdownFactory A countdown timer factory.
+ * @param {!OriginChecker} originChecker An origin checker.
  * @param {!RequestHelper} requestHelper A request helper.
  * @param {!TextFetcher} textFetcher A text fetcher.
  * @constructor
  */
-function FactoryRegistry(countdownFactory, requestHelper,
+function FactoryRegistry(countdownFactory, originChecker, requestHelper,
     textFetcher) {
   /** @private {!CountdownFactory} */
   this.countdownFactory_ = countdownFactory;
+  /** @private {!OriginChecker} */
+  this.originChecker_ = originChecker;
   /** @private {!RequestHelper} */
   this.requestHelper_ = requestHelper;
   /** @private {!TextFetcher} */
@@ -29,6 +32,11 @@ function FactoryRegistry(countdownFactory, requestHelper,
 /** @return {!CountdownFactory} A countdown factory. */
 FactoryRegistry.prototype.getCountdownFactory = function() {
   return this.countdownFactory_;
+};
+
+/** @return {!OriginChecker} An origin checker. */
+FactoryRegistry.prototype.getOriginChecker = function() {
+  return this.originChecker_;
 };
 
 /** @return {!RequestHelper} A request helper. */

--- a/u2f-chrome-extension/gnubby-u2f.js
+++ b/u2f-chrome-extension/gnubby-u2f.js
@@ -40,16 +40,21 @@ Gnubby.U2F_V2 = 'U2F_V2';
  * @param {ArrayBuffer|Uint8Array} challenge Enrollment challenge
  * @param {ArrayBuffer|Uint8Array} appIdHash Hashed application id
  * @param {function(...)} cb Result callback
+ * @param {boolean=} opt_individualAttestation Request the individual
+ *     attestation cert rather than the batch one.
  */
-Gnubby.prototype.enroll = function(challenge, appIdHash, cb) {
+Gnubby.prototype.enroll = function(challenge, appIdHash, cb,
+    opt_individualAttestation) {
+  var p1 = Gnubby.P1_TUP_REQUIRED | Gnubby.P1_TUP_CONSUME;
+  if (opt_individualAttestation) {
+    p1 |= Gnubby.P1_INDIVIDUAL_KEY;
+  }
   var apdu = new Uint8Array(
       [0x00,
        Gnubby.U2F_ENROLL,
-       Gnubby.P1_TUP_REQUIRED | Gnubby.P1_TUP_CONSUME |
-         Gnubby.P1_INDIVIDUAL_KEY,
+       p1,
        0x00, 0x00, 0x00,
        challenge.length + appIdHash.length]);
-  // TODO: only use P1_INDIVIDUAL_KEY for corp appIdHashes.
   var u8 = new Uint8Array(apdu.length + challenge.length +
       appIdHash.length + 2);
   for (var i = 0; i < apdu.length; ++i) u8[i] = apdu[i];

--- a/u2f-chrome-extension/gnubby.js
+++ b/u2f-chrome-extension/gnubby.js
@@ -525,7 +525,10 @@ Gnubby.prototype.sync = function(cb) {
   }
 
   function sendInitSentinel() {
-    var cid = Gnubby.BROADCAST_CID;
+    var cid = self.cid;
+    if (cid == Gnubby.defaultChannelId_(self.gnubbyInstance, self.which)) {
+      cid = Gnubby.BROADCAST_CID;
+    }
     var cmd = GnubbyDevice.CMD_INIT;
     self.dev.queueCommand(cid, cmd, nonce);
   }
@@ -630,8 +633,7 @@ Gnubby.prototype.sync = function(cb) {
     completionAction = syncCompletionAction;
   }
 
-  if (Gnubby.gnubbies_.isSharedAccess(this.which) &&
-      this.cid == Gnubby.defaultChannelId_(this.gnubbyInstance, this.which)) {
+  if (Gnubby.gnubbies_.isSharedAccess(this.which)) {
     setInit();
   } else {
     setSync();

--- a/u2f-chrome-extension/individualattest.js
+++ b/u2f-chrome-extension/individualattest.js
@@ -1,0 +1,26 @@
+// Copyright 2014 Google Inc. All rights reserved
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+/**
+ * @fileoverview Provides an interface to determine whether to request the
+ * individual attestation certificate during enrollment.
+ */
+'use strict';
+
+/**
+ * Interface to determine whether to request the individual attestation
+ * certificate during enrollment.
+ * @interface
+ */
+function IndividualAttestation() {}
+
+/**
+ * @param {string} appIdHash The app id hash.
+ * @return {boolean} Whether to request the individual attestation certificate
+ *     for this app id.
+ */
+IndividualAttestation.prototype.requestIndividualAttestation =
+    function(appIdHash) {};

--- a/u2f-chrome-extension/manifest.json
+++ b/u2f-chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "FIDO U2F (Universal 2nd Factor) extension",
   "description": "Provides the FIDO U2F APIs for authentication. Pre-release, intended for testing by developers creating U2F servers or devices.",
-  "version": "0.8.58",
+  "version": "0.8.60",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqLLJ2LRanry7nH7cJjoIQeg6dorICc8JUQBu+NvkdnK5djBfWF2sHh2fBATBhXbs9UR5MaH8cCoBQNN4vdzYDSfH7NkwJjXMmy7KO2L3UlbMIoHWUolOOYL/ym2gu+fSBn4p5q+5lJ3siFwx9q7Dk36Tn5slwbvt2x+i882umtPI1lgxBE9Iqq6N8+36ZVkkSnS76p2OHP0t60bmTAO1IUkr4zUDhUsARpmDV/QaiYjMRO0VBUUPTtqmxSJ6W+LYTfDAXFEC9bhyLN3n2B70QZPT21TY2j/j0BjragsSv7PbLTloBmRjqCqUCW8/HZffPSTqpFdG5SlwoXDiTeOZ6QIDAQAB",
   "manifest_version": 2,
   "minimum_chrome_version": "36.0.1985.18",
@@ -21,12 +21,40 @@
           "productId": 512
         },
         {
+          "vendorId": 4176,
+          "productId": 275
+        },
+        {
+          "vendorId": 4176,
+          "productId": 276
+        },
+        {
+          "vendorId": 4176,
+          "productId": 277
+        },
+        {
+          "vendorId": 4176,
+          "productId": 288
+        },
+        {
+          "vendorId": 4176,
+          "productId": 1025
+        },
+        {
+          "vendorId": 4176,
+          "productId": 1026
+        },
+        {
           "vendorId": 9601,
           "productId": 61904
         },
         {
           "vendorId": 7223,
           "productId": 61904
+        },
+        {
+          "vendorId": 1419,
+          "productId": 24579
         }
       ]
     }
@@ -49,7 +77,6 @@
       "errorcodes.js",
       "gnubbycodetypes.js",
       "webrequest.js",
-      "gnubbyfactory.js",
       "gnubbymsgtypes.js",
       "messagetypes.js",
       "factoryregistry.js",
@@ -58,19 +85,23 @@
       "enroller.js",
       "requestqueue.js",
       "signer.js",
+      "origincheck.js",
       "textfetcher.js",
-      "etld.js",
       "appid.js",
+      "etld.js",
+      "etldorigincheck.js",
       "gnubbydevice.js",
       "hidgnubbydevice.js",
       "usbgnubbydevice.js",
       "gnubbies.js",
       "gnubby.js",
       "gnubby-u2f.js",
+      "gnubbyfactory.js",
       "singlesigner.js",
       "multiplesigner.js",
       "generichelper.js",
       "inherits.js",
+      "individualattest.js",
       "devicefactoryregistry.js",
       "usbhelper.js",
       "usbenrollhandler.js",
@@ -79,6 +110,7 @@
       "delegatinghelper.js",
       "externalhelper.js",
       "helperwhitelist.js",
+      "noindividualattest.js",
       "u2fbackground.js"
     ]
   },

--- a/u2f-chrome-extension/noindividualattest.js
+++ b/u2f-chrome-extension/noindividualattest.js
@@ -1,0 +1,28 @@
+// Copyright 2014 Google Inc. All rights reserved
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+/**
+ * @fileoverview Provides a default implementation of IndividualAttestation.
+ */
+'use strict';
+
+/**
+ * Default implementation of IndividualAttestation that always returns no,
+ * i.e. only requests the batch attestation certificate.
+ * @constructor
+ * @implements IndividualAttestation
+ */
+function NoIndividualAttestation() {}
+
+/**
+ * @param {string} appIdHash The app id hash.
+ * @return {boolean} Whether to request the individual attestation certificate
+ *     for this app id.
+ */
+NoIndividualAttestation.prototype.requestIndividualAttestation =
+    function(appIdHash) {
+  return false;
+};

--- a/u2f-chrome-extension/origincheck.js
+++ b/u2f-chrome-extension/origincheck.js
@@ -1,0 +1,28 @@
+// Copyright 2014 Google Inc. All rights reserved
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+/**
+ * @fileoverview Implements a check whether an origin is allowed to assert an
+ * app id.
+ *
+ */
+'use strict';
+
+/**
+ * Implements half of the app id policy: whether an origin is allowed to claim
+ * an app id. For checking whether the app id also lists the origin,
+ * @see AppIdChecker.
+ * @interface
+ */
+function OriginChecker() {}
+
+/**
+ * Checks whether the origin is allowed to claim the app ids.
+ * @param {string} origin The origin claiming the app id.
+ * @param {!Array.<string>} appIds The app ids being claimed.
+ * @return {Promise.<boolean>} A promise for the result of the check.
+ */
+OriginChecker.prototype.canClaimAppIds = function(origin, appIds) {};

--- a/u2f-chrome-extension/signer.js
+++ b/u2f-chrome-extension/signer.js
@@ -346,6 +346,23 @@ Signer.prototype.checkAppIds_ = function() {
     this.notifyError_(ErrorCodes.BAD_REQUEST);
     return;
   }
+  FACTORY_REGISTRY.getOriginChecker().canClaimAppIds(this.origin_, appIds)
+      .then(this.originChecked_.bind(this, appIds));
+};
+
+/**
+ * Called with the result of checking the origin. When the origin is allowed
+ * to claim the app ids, begins checking whether the app ids also list the
+ * origin.
+ * @param {!Array.<string>} appIds The app ids.
+ * @param {boolean} result Whether the origin could claim the app ids.
+ * @private
+ */
+Signer.prototype.originChecked_ = function(appIds, result) {
+  if (!result) {
+    this.notifyError_(ErrorCodes.BAD_REQUEST);
+    return;
+  }
   /** @private {!AppIdChecker} */
   this.appIdChecker_ = new AppIdChecker(FACTORY_REGISTRY.getTextFetcher(),
       this.timer_.clone(), this.origin_,

--- a/u2f-chrome-extension/u2fbackground.js
+++ b/u2f-chrome-extension/u2fbackground.js
@@ -29,12 +29,14 @@ REQUEST_HELPER.addHelper(new UsbHelper());
 
 var FACTORY_REGISTRY = new FactoryRegistry(
     TIMER_FACTORY,
+    new EtldOriginChecker(),
     REQUEST_HELPER,
     new XhrTextFetcher());
 
 var DEVICE_FACTORY_REGISTRY = new DeviceFactoryRegistry(
     new UsbGnubbyFactory(gnubbies),
-    TIMER_FACTORY);
+    TIMER_FACTORY,
+    new NoIndividualAttestation());
 
 /**
  * Whitelist of allowed external request helpers.

--- a/u2f-chrome-extension/usbenrollhandler.js
+++ b/u2f-chrome-extension/usbenrollhandler.js
@@ -208,10 +208,12 @@ UsbEnrollHandler.prototype.tryEnroll_ = function(gnubby, version) {
     this.removeWrongVersionGnubby_(gnubby);
     return;
   }
-  var challengeChallenge = B64_decode(challenge['challenge']);
+  var challengeValue = B64_decode(challenge['challengeHash']);
   var appIdHash = B64_decode(challenge['appIdHash']);
-  gnubby.enroll(challengeChallenge, appIdHash,
-      this.enrollCallback_.bind(this, gnubby, version));
+  gnubby.enroll(challengeValue, appIdHash,
+      this.enrollCallback_.bind(this, gnubby, version),
+      DEVICE_FACTORY_REGISTRY.getIndividualAttestation().
+          requestIndividualAttestation(appIdHash));
 };
 
 /**


### PR DESCRIPTION
- Implements the proposed eTLD+1 check on appIds
- Tolerate lack of HID init message, as per standard
- Rename challenge to challengeHash in enroll helper messages, to match documentation.
- Some refactoring/cleanups
