### PR TITLE
Bugfix 0.8.68.1

### DIFF
--- a/u2f-chrome-extension/hidgnubbydevice.js
+++ b/u2f-chrome-extension/hidgnubbydevice.js
@@ -76,7 +76,7 @@ HidGnubbyDevice.prototype.destroy = function() {
     if (chrome.runtime.lastError) {
       console.warn(UTIL_fmt('Device ' + dev.connectionId +
           ' couldn\'t be disconnected:'));
-      console.warn(chrome.runtime.lastError);
+      console.warn(UTIL_fmt(chrome.runtime.lastError.message));
       return;
     }
     console.log(UTIL_fmt('Device ' + dev.connectionId + ' closed'));
@@ -192,8 +192,8 @@ HidGnubbyDevice.prototype.readLoop_ = function() {
     this.dev.connectionId,
     function(report_id, data) {
       if (chrome.runtime.lastError || !data) {
-        console.log(UTIL_fmt('got lastError'));
-        console.log(chrome.runtime.lastError);
+        console.log(UTIL_fmt('receive got lastError:'));
+        console.log(UTIL_fmt(chrome.runtime.lastError.message));
         window.setTimeout(function() { self.destroy(); }, 0);
         return;
       }
@@ -371,8 +371,8 @@ HidGnubbyDevice.prototype.writePump_ = function() {
   var self = this;
   function transferComplete() {
     if (chrome.runtime.lastError) {
-      console.log(UTIL_fmt('got lastError'));
-      console.log(chrome.runtime.lastError);
+      console.log(UTIL_fmt('send got lastError:'));
+      console.log(UTIL_fmt(chrome.runtime.lastError.message));
       window.setTimeout(function() { self.destroy(); }, 0);
       return;
     }
@@ -446,7 +446,8 @@ HidGnubbyDevice.enumerate = function(cb) {
 HidGnubbyDevice.open = function(gnubbies, which, dev, cb) {
   chrome.hid.connect(dev.deviceId, function(handle) {
     if (chrome.runtime.lastError) {
-      console.log(chrome.runtime.lastError);
+      console.log(UTIL_fmt('connect got lastError:'));
+      console.log(UTIL_fmt(chrome.runtime.lastError.message));
     }
     if (!handle) {
       console.warn(UTIL_fmt('failed to connect device. permissions issue?'));

--- a/u2f-chrome-extension/manifest.json
+++ b/u2f-chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "FIDO U2F (Universal 2nd Factor) extension",
   "description": "Provides the FIDO U2F APIs for authentication. PRE-RELEASE",
-  "version": "0.8.68",
+  "version": "0.8.68.1",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqLLJ2LRanry7nH7cJjoIQeg6dorICc8JUQBu+NvkdnK5djBfWF2sHh2fBATBhXbs9UR5MaH8cCoBQNN4vdzYDSfH7NkwJjXMmy7KO2L3UlbMIoHWUolOOYL/ym2gu+fSBn4p5q+5lJ3siFwx9q7Dk36Tn5slwbvt2x+i882umtPI1lgxBE9Iqq6N8+36ZVkkSnS76p2OHP0t60bmTAO1IUkr4zUDhUsARpmDV/QaiYjMRO0VBUUPTtqmxSJ6W+LYTfDAXFEC9bhyLN3n2B70QZPT21TY2j/j0BjragsSv7PbLTloBmRjqCqUCW8/HZffPSTqpFdG5SlwoXDiTeOZ6QIDAQAB",
   "manifest_version": 2,
   "minimum_chrome_version": "36.0.1985.18",

--- a/u2f-chrome-extension/usbgnubbydevice.js
+++ b/u2f-chrome-extension/usbgnubbydevice.js
@@ -82,7 +82,7 @@ UsbGnubbyDevice.prototype.destroy = function() {
     if (chrome.runtime.lastError) {
       console.warn(UTIL_fmt('Device ' + dev.handle +
           ' couldn\'t be released:'));
-      console.warn(chrome.runtime.lastError);
+      console.warn(UTIL_fmt(chrome.runtime.lastError.message));
       return;
     }
     console.log(UTIL_fmt('Device ' + dev.handle + ' released'));
@@ -90,7 +90,7 @@ UsbGnubbyDevice.prototype.destroy = function() {
       if (chrome.runtime.lastError) {
         console.warn(UTIL_fmt('Device ' + dev.handle +
             ' couldn\'t be closed:'));
-        console.warn(chrome.runtime.lastError);
+        console.warn(UTIL_fmt(chrome.runtime.lastError.message));
         return;
       }
       console.log(UTIL_fmt('Device ' + dev.handle + ' closed'));
@@ -149,8 +149,8 @@ UsbGnubbyDevice.prototype.readOneReply_ = function() {
     if (!self.readyToUse_()) return;  // No point in continuing.
 
     if (chrome.runtime.lastError) {
-      console.warn(UTIL_fmt('lastError: ' + chrome.runtime.lastError));
-      console.log(chrome.runtime.lastError);
+      console.warn(UTIL_fmt('in bulkTransfer got lastError: '));
+      console.warn(UTIL_fmt(chrome.runtime.lastError.message));
       window.setTimeout(function() { self.destroy(); }, 0);
       return;
     }
@@ -246,8 +246,8 @@ UsbGnubbyDevice.prototype.writeOneRequest_ = function() {
     if (!self.readyToUse_()) return;  // No point in continuing.
 
     if (chrome.runtime.lastError) {
-      console.warn(UTIL_fmt('lastError: ' + chrome.runtime.lastError));
-      console.log(chrome.runtime.lastError);
+      console.warn(UTIL_fmt('out bulkTransfer lastError: '));
+      console.warn(UTIL_fmt(chrome.runtime.lastError.message));
       window.setTimeout(function() { self.destroy(); }, 0);
       return;
     }
@@ -456,6 +456,8 @@ UsbGnubbyDevice.open = function(gnubbies, which, dev, cb) {
   /** @param {chrome.usb.ConnectionHandle=} handle Connection handle */
   function deviceOpened(handle) {
     if (chrome.runtime.lastError) {
+      console.warn(UTIL_fmt('openDevice got lastError:'));
+      console.warn(UTIL_fmt(chrome.runtime.lastError.message));
       console.warn(UTIL_fmt('failed to open device. permissions issue?'));
       cb(-GnubbyDevice.NODEVICE);
       return;

--- a/u2f-chrome-extension/userapprovedorigins.js
+++ b/u2f-chrome-extension/userapprovedorigins.js
@@ -31,6 +31,10 @@ function UserApprovedOrigins() {
  * @return {Promise.<boolean>} A promise for the result of the check.
  */
 UserApprovedOrigins.prototype.isApprovedOrigin = function(origin, opt_tabId) {
+  if (!chrome.infobars) {
+    // No infobar to show? Have to allow it.
+    return Promise.resolve(true);
+  }
   var etldOriginChecker =
       /** @type {EtldOriginChecker} */ (FACTORY_REGISTRY.getOriginChecker());
   var etldFetcher = etldOriginChecker.getFetcher();


### PR DESCRIPTION
- Only trigger infobar if the API is actually available
- Log strings instead of objects, better for chrome://extensions
