### PR TITLE
add animation back to highlight blink

### DIFF
--- a/u2f-gae-demo/war/js/u2fdemo.js
+++ b/u2f-gae-demo/war/js/u2fdemo.js
@@ -77,18 +77,16 @@ function highlightTokenCardOnPage(token) {
   console.log(token);
 
   var cardChildren = document.getElementById(token.public_key).children;
-  var cardChildrenOldClassNames = [];
   for (i = 0; i < cardChildren.length; i++) {
-    cardChildrenOldClassNames.push(cardChildren[i].className);
     if (cardChildren[i].className.indexOf("cardContent") > -1) {
-      cardChildren[i].className += " highlight";
+      $(cardChildren[i]).addClass("highlight");
     }
   }
 
   window.setTimeout(
     function() {
       for (i = 0; i < cardChildren.length; i++) {
-        cardChildren[i].className = cardChildrenOldClassNames[i];
+        $(cardChildren[i]).removeClass("highlight", 2000);
       }
     },
     500

--- a/u2f-gae-demo/war/js/u2fdemo.js
+++ b/u2f-gae-demo/war/js/u2fdemo.js
@@ -78,7 +78,7 @@ function highlightTokenCardOnPage(token) {
 
   var cardChildren = document.getElementById(token.public_key).children;
   for (i = 0; i < cardChildren.length; i++) {
-    if (cardChildren[i].className.indexOf("cardContent") > -1) {
+    if ($(cardChildren[i]).hasClass("cardContent")) {
       $(cardChildren[i]).addClass("highlight");
     }
   }


### PR DESCRIPTION
The original jQuery has a faded animation effect on the highlight (although it does not work on iOS). Now add the animation back and works on all platforms.