### PR TITLE
Rename a function and document its usage, for increased clarity.

### DIFF
--- a/u2f-tests/HID/U2FTest.cc
+++ b/u2f-tests/HID/U2FTest.cc
@@ -85,7 +85,7 @@ void test_Version() {
   buf[6] = 0;  // Lc = 0 (Not ISO 7816-4 compliant)
   buf[7] = 0;  // Le = 0
   buf[8] = 0;  // Le = 0
-  CHECK_EQ(0x9000, U2Fob_exchange(device, buf, sizeof(buf), &rsp));
+  CHECK_EQ(0x9000, U2Fob_exchange_apdu_buffer(device, buf, sizeof(buf), &rsp));
   CHECK_EQ(rsp, "U2F_V2");
 }
 

--- a/u2f-tests/HID/u2f_util.cc
+++ b/u2f-tests/HID/u2f_util.cc
@@ -344,10 +344,10 @@ int U2Fob_recv(struct U2Fob* device, uint8_t* cmd,
   return result;
 }
 
-int U2Fob_exchange(struct U2Fob* device,
-                   void* data,
-                   size_t size,
-                   std::string* in) {
+int U2Fob_exchange_apdu_buffer(struct U2Fob* device,
+                               void* data,
+                               size_t size,
+                               std::string* in) {
   uint8_t cmd = U2FHID_MSG;
 
   int res = U2Fob_send(device, cmd, data, size);
@@ -404,7 +404,7 @@ int U2Fob_apdu(struct U2Fob* device,
   buf[offs++] = 0;
   buf[offs++] = 0;
 
-  return U2Fob_exchange(device, buf, offs, in);
+  return U2Fob_exchange_apdu_buffer(device, buf, offs, in);
 }
 
 bool getCertificate(const U2F_REGISTER_RESP& rsp,

--- a/u2f-tests/HID/u2f_util.h
+++ b/u2f-tests/HID/u2f_util.h
@@ -109,14 +109,17 @@ int U2Fob_recv(struct U2Fob* device, uint8_t* cmd,
                void* data, size_t size,
                float timeoutSeconds);
 
+// Exchanges a pre-formatted APDU buffer with the device.
 // returns
 //   negative error
 //   positive sw12, e.g. 0x9000, 0x6985 etc.
-int U2Fob_exchange(struct U2Fob* device,
-                   void* data,
-                   size_t size,
-                   std::string* in);
+int U2Fob_exchange_apdu_buffer(struct U2Fob* device,
+                               void* data,
+                               size_t size,
+                               std::string* in);
 
+// Formats an APDU with the given field values, and exchanges it
+// with the device.
 // returns
 //   negative error
 //   positive sw12, e.g. 0x9000, 0x6985 etc.


### PR DESCRIPTION
@leshi, following up on a comment you made to pull 68.