### PR TITLE
Send fewer appIds

### DIFF
--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginEnrollServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginEnrollServlet.java
@@ -51,8 +51,8 @@ public class BeginEnrollServlet extends HttpServlet {
       throw new ServletException("couldn't get registration request", e);
     }
 
-	  JsonObject result = new JsonObject();
-    result.addProperty("appId", registrationRequest.getAppId());
+    JsonObject result = new JsonObject();
+    result.addProperty("appId", appId);
     result.addProperty("sessionId", registrationRequest.getSessionId());
     
 	  JsonObject registerRequests = new JsonObject();
@@ -63,7 +63,7 @@ public class BeginEnrollServlet extends HttpServlet {
 		if(allowReregistration) {
 		  result.add("registeredKeys", new JsonArray());
 		} else {
-		  result.add("registeredKeys", signRequest.getRegisteredKeysAsJson());
+		  result.add("registeredKeys", signRequest.getRegisteredKeysAsJson(appId));
 		}
 
 		resp.setContentType("application/json");

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
@@ -49,7 +49,7 @@ public class BeginSignServlet extends HttpServlet {
     JsonObject result = new JsonObject();
     result.addProperty("challenge", signRequest.getChallenge());
     result.addProperty("appId", appId);
-    result.add("registeredKeys", signRequest.getRegisteredKeysAsJson());
+    result.add("registeredKeys", signRequest.getRegisteredKeysAsJson(appId));
 
     resp.setContentType("application/json");
     resp.getWriter().println(result.toString());

--- a/u2f-ref-code/java/src/com/google/u2f/server/messages/RegisteredKey.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/messages/RegisteredKey.java
@@ -111,9 +111,11 @@ public class RegisteredKey {
     return transportsArray;
   }
 
-  public JsonObject getJson() {
+  public JsonObject getJson(String defaultAppId) {
     JsonObject result = new JsonObject();
-    result.addProperty("appId", appId);
+    if (appId != null && !appId.equals(defaultAppId)) {
+      result.addProperty("appId", appId);
+    }
     result.addProperty("version", version);
     result.addProperty("keyHandle", keyHandle);
     result.addProperty("sessionId", sessionId);

--- a/u2f-ref-code/java/src/com/google/u2f/server/messages/U2fSignRequest.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/messages/U2fSignRequest.java
@@ -29,13 +29,13 @@ public class U2fSignRequest {
     return registeredKeys;
   }
 
-  public JsonArray getRegisteredKeysAsJson() {
+  public JsonArray getRegisteredKeysAsJson(String defaultAppId) {
     if (registeredKeys == null) {
       return null;
     }
     JsonArray result = new JsonArray();
     for (RegisteredKey registeredKey : registeredKeys) {
-      result.add(registeredKey.getJson());
+      result.add(registeredKey.getJson(defaultAppId));
     }
     return result;
   }

--- a/u2f-ref-code/java/src/com/google/u2f/tools/httpserver/servlets/SignDataServlet.java
+++ b/u2f-ref-code/java/src/com/google/u2f/tools/httpserver/servlets/SignDataServlet.java
@@ -32,11 +32,12 @@ public class SignDataServlet extends JavascriptServlet {
       return;
     }
 
-    U2fSignRequest signRequest = u2fServer.getSignRequest(userName, "http://localhost:8080");
+    String appId = "http://localhost:8080";
+    U2fSignRequest signRequest = u2fServer.getSignRequest(userName, appId);
     JsonObject result = new JsonObject();
     result.addProperty("challenge", signRequest.getChallenge());
-    result.addProperty("appId", "http://localhost:8080");
-    result.add("registeredKeys", signRequest.getRegisteredKeysAsJson());
+    result.addProperty("appId", appId);
+    result.add("registeredKeys", signRequest.getRegisteredKeysAsJson(appId));
 
     body.println("var signData = " + result.toString() + ";");
   }


### PR DESCRIPTION
Don't send the appId for a registeredKey unless it differs from the request's default appId.

Closes #74.