### PR TITLE
Send transports as defined in the U2F JavaScript API.

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/server/data/SecurityKeyData.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/data/SecurityKeyData.java
@@ -16,10 +16,21 @@ import com.google.common.base.Objects;
 
 public class SecurityKeyData {
   public enum Transports {
-    BLUETOOTH_RADIO,
-    BLUETOOTH_LOW_ENERGY,
-    USB,
-    NFC
+    BLUETOOTH_BREDR("bt"),
+    BLUETOOTH_LOW_ENERGY("ble"),
+    USB("usb"),
+    NFC("nfc");
+
+    private String mValue;
+
+    Transports(String value) {
+      mValue = value;
+    }
+
+    @Override
+    public String toString() {
+      return mValue;
+    }
   }
 
   private final long enrollmentTime;
@@ -77,7 +88,7 @@ public class SecurityKeyData {
   }
 
   public int getCounter() {
-	return counter;
+    return counter;
   }
 
   public void setCounter(int newCounterValue) {

--- a/u2f-ref-code/java/src/com/google/u2f/server/messages/RegisteredKey.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/messages/RegisteredKey.java
@@ -6,6 +6,7 @@
 
 package com.google.u2f.server.messages;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,9 +30,10 @@ public class RegisteredKey {
   private final String keyHandle;
 
   /**
-   * 
+   * The transports registered for this key handle.
    */
   private final List<Transports> transports;
+
   /**
    * The application id that the RP would like to assert. The U2F token will
    * enforce that the key handle provided above is associated with this
@@ -66,7 +68,7 @@ public class RegisteredKey {
   public List<Transports> getTransports() {
     return transports;
   }
-  
+
   public String getAppId() {
     return appId;
   }
@@ -100,17 +102,6 @@ public class RegisteredKey {
         && Objects.equals(sessionId, other.sessionId);
   }
 
-  private JsonArray getTransportsAsJson() {
-    if (this.transports == null) {
-      return null;
-    }
-    JsonArray transportsArray =  new JsonArray();
-    for (Transports transport : this.transports) {
-      transportsArray.add(new JsonPrimitive(transport.toString()));
-    }
-    return transportsArray;
-  }
-
   public JsonObject getJson(String defaultAppId) {
     JsonObject result = new JsonObject();
     if (appId != null && !appId.equals(defaultAppId)) {
@@ -119,10 +110,24 @@ public class RegisteredKey {
     result.addProperty("version", version);
     result.addProperty("keyHandle", keyHandle);
     result.addProperty("sessionId", sessionId);
-    JsonArray transportsJson = getTransportsAsJson();
-    if (transportsJson != null) {
-      result.add("transports", transportsJson);
+    String transportsString = getTransportsAsString();
+    if (transportsString != null) {
+      result.addProperty("transports", transportsString);
     }
     return result;
+  }
+
+  private String getTransportsAsString() {
+    if (this.transports == null) {
+      return null;
+    }
+    StringBuilder stringBuilder = new StringBuilder();
+    for (int i = 0; i < transports.size(); i++) {
+      stringBuilder.append(transports.get(i));
+      if (i < transports.size() - 1) {
+        stringBuilder.append(",");
+      }
+    }
+    return stringBuilder.toString();
   }
 }

--- a/u2f-ref-code/java/tests/com/google/u2f/server/impl/U2FServerReferenceImplTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/server/impl/U2FServerReferenceImplTest.java
@@ -121,7 +121,7 @@ public class U2FServerReferenceImplTest extends TestVectors {
     u2fServer.processRegistrationResponse(registrationResponse, 0L);
 
     List<Transports> transports = new LinkedList<Transports>();
-    transports.add(Transports.BLUETOOTH_RADIO);
+    transports.add(Transports.BLUETOOTH_BREDR);
     verify(mockDataStore).addSecurityKeyData(eq(ACCOUNT_NAME),
         eq(new SecurityKeyData(0L, transports, KEY_HANDLE, USER_PUBLIC_KEY_ENROLL_HEX,
             TRUSTED_CERTIFICATE_ONE_TRANSPORT, 0)));
@@ -143,7 +143,7 @@ public class U2FServerReferenceImplTest extends TestVectors {
     u2fServer.processRegistrationResponse(registrationResponse, 0L);
 
     List<Transports> transports = new LinkedList<Transports>();
-    transports.add(Transports.BLUETOOTH_RADIO);
+    transports.add(Transports.BLUETOOTH_BREDR);
     transports.add(Transports.BLUETOOTH_LOW_ENERGY);
     transports.add(Transports.NFC);
     verify(mockDataStore).addSecurityKeyData(eq(ACCOUNT_NAME),


### PR DESCRIPTION
Make the transports enum contain the string value used by the API.
Send the transports value as a comma-delimited string, rather than
a JSON array.

Closes #75.