### PR TITLE
Refactor parsing methods for better readability

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/server/impl/attestation/X509ExtensionParsingUtil.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/impl/attestation/X509ExtensionParsingUtil.java
@@ -1,17 +1,37 @@
 package com.google.u2f.server.impl.attestation;
 
+import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Object;
+import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.DLSequence;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
+import java.util.HashMap;
 
 /**
  * A set of utilities for parsing X509 Extensions
  */
 public class X509ExtensionParsingUtil {
+  // Don't expect more than 32 bits for any INTEGER
+  private static final int MAX_INT_BITS = 32;
+  private static final int MAX_LONG_BITS = 64;
+
+  /**
+   * Extract a {@link DEROctetString} that represents the value of a given extension
+   *
+   * @param cert is X509 certificate out of which an extension should be extracted
+   * @param Oid is the Object IDentifier for the extension
+   * @return a {@link DEROctetString} that represents an extension or {@code null} if no such
+   * extension is found.
+   * @throws CertificateParsingException if a parsing error occurs
+   */
   public static DEROctetString extractExtensionValue(X509Certificate cert, String Oid)
       throws CertificateParsingException {
     byte[] extensionValue = cert.getExtensionValue(Oid);
@@ -21,14 +41,18 @@ public class X509ExtensionParsingUtil {
       return null;
     }
 
-    ASN1Object asn1Object  = getAsn1Object(extensionValue);
+    ASN1Object asn1Object = getAsn1Object(extensionValue);
     if (asn1Object == null || !(asn1Object instanceof DEROctetString)) {
       throw new CertificateParsingException("Expected DEROctetString.");
     }
-    
+
     return (DEROctetString) asn1Object;
   }
-  
+
+  /**
+   * Extracts an {@link ASN1Object} from an array of octets
+   * @throws CertificateParsingException
+   */
   public static ASN1Object getAsn1Object(byte[] octets) throws CertificateParsingException {
     ASN1InputStream ais = new ASN1InputStream(octets);
     // Read the key description octet string
@@ -40,8 +64,71 @@ public class X509ExtensionParsingUtil {
       try {
         ais.close();
       } catch (IOException e) {
-        throw new CertificateParsingException("Not able to close ASN.1 stream", e);  
+        throw new CertificateParsingException("Not able to close ASN.1 stream", e);
       }
     }
+  }
+
+  /**
+   * Extracts an {@code int} from an {@link ASN1Encodable}.
+   * @throws CertificateParsingException
+   */
+  public static int getInt(ASN1Encodable asn1Encodable) throws CertificateParsingException {
+    if (asn1Encodable == null || !(asn1Encodable instanceof ASN1Integer)) {
+      throw new CertificateParsingException("Expected INTEGER type.");
+    }
+    ASN1Integer asn1Integer = (ASN1Integer) asn1Encodable;
+    BigInteger bigInt = asn1Integer.getPositiveValue();
+    if (bigInt.bitLength() > MAX_INT_BITS) {
+      throw new CertificateParsingException("INTEGER too big");
+    }
+    return bigInt.intValue();
+  }
+
+  /**
+   * Extracts an {@code long} from an {@link ASN1Encodable}.
+   * @throws CertificateParsingException
+   */
+  public static long getLong(ASN1Encodable asn1Encodable) throws CertificateParsingException {
+    if (asn1Encodable == null || !(asn1Encodable instanceof ASN1Integer)) {
+      throw new CertificateParsingException("Expected INTEGER type.");
+    }
+    ASN1Integer asn1Integer = (ASN1Integer) asn1Encodable;
+    BigInteger bigInt = asn1Integer.getPositiveValue();
+    if (bigInt.bitLength() > MAX_LONG_BITS) {
+      throw new CertificateParsingException("INTEGER too big");
+    }
+    return bigInt.longValue();
+  }
+
+  /**
+   * Extracts a {@code byte[]} from an {@link ASN1Encodable}
+   */
+  public static byte[] getByteArray(ASN1Encodable asn1Encodable)
+      throws CertificateParsingException {
+    if (asn1Encodable == null || !(asn1Encodable instanceof DEROctetString)) {
+      throw new CertificateParsingException("Expected DEROctetString");
+    }
+    DEROctetString derOctectString = (DEROctetString) asn1Encodable;
+    return derOctectString.getOctets();
+  }
+
+  /**
+   * Returns a {@link HashMap} whose keys represent the tags and whose values represent the values
+   * of a {@link DLSequence}.
+   */
+  public static HashMap<Integer, ASN1Primitive> extractTaggedObjects(DLSequence dlSequence)
+      throws CertificateParsingException {
+    HashMap<Integer, ASN1Primitive> taggedObjects = new HashMap<Integer, ASN1Primitive>();
+
+    for (ASN1Encodable asn1EncodablePurpose : dlSequence.toArray()) {
+      if (asn1EncodablePurpose == null || !(asn1EncodablePurpose instanceof DERTaggedObject)) {
+        throw new CertificateParsingException("Expected DERTagged object");
+      }
+      DERTaggedObject derTaggedObject = (DERTaggedObject) asn1EncodablePurpose;
+      taggedObjects.put(Integer.valueOf(derTaggedObject.getTagNo()), derTaggedObject.getObject());
+    }
+
+    return taggedObjects;
   }
 }

--- a/u2f-ref-code/java/src/com/google/u2f/server/impl/attestation/android/AndroidKeyStoreAttestation.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/impl/attestation/android/AndroidKeyStoreAttestation.java
@@ -3,15 +3,12 @@ package com.google.u2f.server.impl.attestation.android;
 import com.google.u2f.server.impl.attestation.X509ExtensionParsingUtil;
 
 import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSet;
-import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.DLSequence;
 
-import java.math.BigInteger;
 import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -30,10 +27,6 @@ public class AndroidKeyStoreAttestation {
   private static final int DESCRIPTION_CHALLENGE_INDEX = 1;
   private static final int DESCRIPTION_SOFTWARE_ENFORCED_INDEX = 2;
   private static final int DESCRIPTION_TEE_ENFORCED_INDEX = 3;
-
-  // Don't expect more than 32 bits for any INTEGER
-  private static final int MAX_INT_BITS = 32;
-  private static final int MAX_LONG_BITS = 64;
 
   // Tags for Authorization List
   private static final int AUTHZ_PURPOSE_TAG = 1;
@@ -135,7 +128,7 @@ public class AndroidKeyStoreAttestation {
     // Extract the extension from the certificate
     DEROctetString extensionValue =
         X509ExtensionParsingUtil.extractExtensionValue(cert, KEY_DESCRIPTION_OID);
-    
+
     if (extensionValue == null) {
       return null;
     }
@@ -207,65 +200,27 @@ public class AndroidKeyStoreAttestation {
     return (DLSequence) asn1Encodable;
   }
 
-  private static int getIntFromAsn1Encodable(ASN1Encodable asn1Encodable)
-      throws CertificateParsingException {
-    if (asn1Encodable == null || !(asn1Encodable instanceof ASN1Integer)) {
-      throw new CertificateParsingException("Expected INTEGER type.");
-    }
-    ASN1Integer asn1Integer = (ASN1Integer) asn1Encodable;
-    BigInteger bigInt = asn1Integer.getPositiveValue();
-    if (bigInt.bitLength() > MAX_INT_BITS) {
-      throw new CertificateParsingException("INTEGER too big");
-    }
-    return bigInt.intValue();
-  }
-
-  private static byte[] getByteArrayFromAsn1Encodable(ASN1Encodable asn1Encodable)
-      throws CertificateParsingException {
-    if (asn1Encodable == null || !(asn1Encodable instanceof DEROctetString)) {
-      throw new CertificateParsingException("Expected DEROctetString");
-    }
-    DEROctetString derOctectString = (DEROctetString) asn1Encodable;
-    return derOctectString.getOctets();
-  }
-
-  private static int checkValidTag(int tag) {
-    // TODO(aczeskis): implement
-    return tag;
-  }
-
-  private static HashMap<Integer, ASN1Primitive> extractTaggedObjects(DLSequence dlSequence)
-      throws CertificateParsingException {
-    HashMap<Integer, ASN1Primitive> taggedObjects = new HashMap<Integer, ASN1Primitive>();
-
-    for (ASN1Encodable asn1EncodablePurpose : dlSequence.toArray()) {
-      if (asn1EncodablePurpose == null || !(asn1EncodablePurpose instanceof DERTaggedObject)) {
-        throw new CertificateParsingException("Expected DERTagged object");
-      }
-      DERTaggedObject derTaggedObject = (DERTaggedObject) asn1EncodablePurpose;
-      taggedObjects.put(
-          Integer.valueOf(checkValidTag(derTaggedObject.getTagNo())), derTaggedObject.getObject());
-    }
-
-    return taggedObjects;
-  }
-
   private static int getKeymasterVersion(DLSequence keyDescriptionSequence)
       throws CertificateParsingException {
     ASN1Encodable asn1Encodable = keyDescriptionSequence.getObjectAt(DESCRIPTION_VERSION_INDEX);
-    return getIntFromAsn1Encodable(asn1Encodable);
+    return X509ExtensionParsingUtil.getInt(asn1Encodable);
   }
 
   private static byte[] getAttestationChallenge(DLSequence keyDescriptionSequence)
       throws CertificateParsingException {
     ASN1Encodable asn1Encodable = keyDescriptionSequence.getObjectAt(DESCRIPTION_CHALLENGE_INDEX);
-    return getByteArrayFromAsn1Encodable(asn1Encodable);
+    return X509ExtensionParsingUtil.getByteArray(asn1Encodable);
   }
 
   private static List<Purpose> getPurpose(
       HashMap<Integer, ASN1Primitive> softwareEnforcedTaggedObjects)
       throws CertificateParsingException {
     ASN1Primitive asn1Primitive = softwareEnforcedTaggedObjects.get(AUTHZ_PURPOSE_TAG);
+    if (asn1Primitive == null) {
+      // No purpose found
+      return null;
+    }
+
     if (!(asn1Primitive instanceof DERSet)) {
       throw new CertificateParsingException("Expected DERSet");
     }
@@ -273,7 +228,7 @@ public class AndroidKeyStoreAttestation {
     DERSet set = (DERSet) asn1Primitive;
     List<Purpose> purpose = new ArrayList<Purpose>();
     for (ASN1Encodable asn1Encodable : set.toArray()) {
-      purpose.add(Purpose.fromValue(getIntFromAsn1Encodable(asn1Encodable)));
+      purpose.add(Purpose.fromValue(X509ExtensionParsingUtil.getInt(asn1Encodable)));
     }
 
     return purpose;
@@ -283,13 +238,17 @@ public class AndroidKeyStoreAttestation {
       HashMap<Integer, ASN1Primitive> softwareEnforcedTaggedObjects)
       throws CertificateParsingException {
     ASN1Primitive asn1Primitive = softwareEnforcedTaggedObjects.get(AUTHZ_ALGORITHM_TAG);
-    return Algorithm.fromValue(getIntFromAsn1Encodable(asn1Primitive));
+    if (asn1Primitive == null) {
+      // No algorithm found
+      return null;
+    }
+    return Algorithm.fromValue(X509ExtensionParsingUtil.getInt(asn1Primitive));
   }
 
   private static AuthorizationList extractAuthorizationList(DLSequence authorizationSequence)
       throws CertificateParsingException {
     HashMap<Integer, ASN1Primitive> softwareEnforcedTaggedObjects =
-        extractTaggedObjects(authorizationSequence);
+        X509ExtensionParsingUtil.extractTaggedObjects(authorizationSequence);
 
     return new AuthorizationList.Builder()
         .setPurpose(getPurpose(softwareEnforcedTaggedObjects))

--- a/u2f-ref-code/java/src/com/google/u2f/server/impl/attestation/android/AndroidKeyStoreAttestation.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/impl/attestation/android/AndroidKeyStoreAttestation.java
@@ -35,12 +35,14 @@ public class AndroidKeyStoreAttestation {
   private final int keymasterVersion;
   private final byte[] attestationChallenge;
   private final AuthorizationList softwareAuthorizationList;
+  private final AuthorizationList teeAuthorizationList;
 
   private AndroidKeyStoreAttestation(Integer keymasterVersion, byte[] attestationChallenge,
-      AuthorizationList softwareAuthorizationList) {
+      AuthorizationList softwareAuthorizationList, AuthorizationList teeAuthorizationList) {
     this.keymasterVersion = keymasterVersion;
     this.attestationChallenge = attestationChallenge;
     this.softwareAuthorizationList = softwareAuthorizationList;
+    this.teeAuthorizationList = teeAuthorizationList;
   }
 
   /**
@@ -147,9 +149,13 @@ public class AndroidKeyStoreAttestation {
     AuthorizationList softwareAuthorizationList =
         extractAuthorizationList(softwareEnforcedSequence);
 
-    // TODO(aczeskis) Extract the TEE authorization list
+    // TODO(aczeskis): uncomment when I get a cert that has correct teeEnforced element
+    // Extract the tee authorization list
+    //DLSequence teeEnforcedSequence = getTeeEncodedSequence(keyDescriptionSequence);
+    //AuthorizationList teeAuthorizationList = extractAuthorizationList(teeEnforcedSequence);
 
-    return new AndroidKeyStoreAttestation(keymasterVersion, challenge, softwareAuthorizationList);
+    return new AndroidKeyStoreAttestation(
+        keymasterVersion, challenge, softwareAuthorizationList, null);
   }
 
   /**
@@ -171,6 +177,13 @@ public class AndroidKeyStoreAttestation {
    */
   public byte[] getAttestationChallenge() {
     return attestationChallenge;
+  }
+
+  /**
+   * @return the parsed TEE authorization list
+   */
+  public AuthorizationList getTeeAuthorizationList() {
+    return teeAuthorizationList;
   }
 
   private static DLSequence getKeyDescriptionSequence(DEROctetString octet)
@@ -196,6 +209,16 @@ public class AndroidKeyStoreAttestation {
         keyDescriptionSequence.getObjectAt(DESCRIPTION_SOFTWARE_ENFORCED_INDEX);
     if (asn1Encodable == null || !(asn1Encodable instanceof DLSequence)) {
       throw new CertificateParsingException("Expected softwareEnforced DLSequence.");
+    }
+    return (DLSequence) asn1Encodable;
+  }
+
+  private static DLSequence getTeeEncodedSequence(DLSequence keyDescriptionSequence)
+      throws CertificateParsingException {
+    ASN1Encodable asn1Encodable =
+        keyDescriptionSequence.getObjectAt(DESCRIPTION_TEE_ENFORCED_INDEX);
+    if (asn1Encodable == null || !(asn1Encodable instanceof DLSequence)) {
+      throw new CertificateParsingException("Expected teeEnforced DLSequence.");
     }
     return (DLSequence) asn1Encodable;
   }

--- a/u2f-ref-code/java/tests/com/google/u2f/server/impl/attestation/android/AndroidKeyStoreAttestationTest.java
+++ b/u2f-ref-code/java/tests/com/google/u2f/server/impl/attestation/android/AndroidKeyStoreAttestationTest.java
@@ -32,22 +32,32 @@ public class AndroidKeyStoreAttestationTest extends TestVectors {
     assertArrayEquals(
         "Incorrect challenge", "challenge".getBytes(), attestation.getAttestationChallenge());
 
-    // Get software authz list
+    // Get software authorization list
     AuthorizationList softwareAuthorizationList = attestation.getSoftwareAuthorizationList();
     assertNotNull("Not expecting null software authorization list", softwareAuthorizationList);
 
     // Check purpose
-    assertEquals("Incorrect purpose list size", 2, softwareAuthorizationList.getPurpose().size());
+    assertEquals("Incorrect software authorization list purpose list size", 2,
+        softwareAuthorizationList.getPurpose().size());
     assertTrue(
-        "Purpose list doesn't have SIGN",
+        "Software authorization list purpose list doesn't have SIGN",
         softwareAuthorizationList.getPurpose().contains(Purpose.KM_PURPOSE_SIGN));
     assertTrue(
-        "Purpose list doesn't have VERIFY",
+        "Software authorization list purpose list doesn't have VERIFY",
         softwareAuthorizationList.getPurpose().contains(Purpose.KM_PURPOSE_VERIFY));
 
     // Check algorithm
-    assertEquals("Incorrect algorithm", Algorithm.KM_ALGORITHM_EC,
+    assertEquals("Software authorization list incorrect algorithm", Algorithm.KM_ALGORITHM_EC,
         softwareAuthorizationList.getAlgorithm());
+
+    // TODO(aczeskis): uncomment when I get a cert that has correct teeEnforced element
+    // Get the TEE authorization list
+    //AuthorizationList teeAuthorizationList = attestation.getTeeAuthorizationList();
+    //assertNotNull("Not expecting null TEE authorization list", teeAuthorizationList);
+    //assertEquals(
+    //    "Expecting null TEE authorization list purpose", null, teeAuthorizationList.getPurpose());
+    //assertEquals("Expecting null TEE authorization list algorithm", null,
+    //    teeAuthorizationList.getAlgorithm());
   }
 
   @Test(expected = CertificateParsingException.class)


### PR DESCRIPTION
+ moves generic parsing methods out of android attestation class
+ adds teeEnforced parsing code, but commented out for now (need test vector)