### PR TITLE
Remove jQuery dependency from u2f-api

### DIFF
--- a/u2f-gae-demo/war/js/u2f-api.js
+++ b/u2f-gae-demo/war/js/u2f-api.js
@@ -230,7 +230,7 @@ u2f.isAndroidChrome_ = function() {
  * @private
  */
 u2f.isIosChrome_ = function() {
-  return $.inArray(navigator.platform, ["iPhone", "iPad", "iPod"]) > -1;
+  return ["iPhone", "iPad", "iPod"].indexOf(navigator.platform) > -1;
 };
 
 /**


### PR DESCRIPTION
Copying this from @mislav's branch at https://github.com/mastahyeti/u2f-api/pull/8. There's one jQuery usage in the u2f-api that can be removed. Removing this removes the polyfill's dependency on jQuery.