### PR TITLE
Reinitialize the device.

### DIFF
--- a/u2f-tests/HID/HIDTest.cc
+++ b/u2f-tests/HID/HIDTest.cc
@@ -630,10 +630,14 @@ int main(int argc, char* argv[]) {
   PASS(test_Lock());
 
   PASS(test_Echo());
+  //Re-initialize the device
+  PASS(test_BasicInit());
   PASS(test_LongEcho());
 
   PASS(test_Timeout());
 
+  //Re-initialize the device
+  PASS(test_BasicInit());
   PASS(test_WrongSeq());
   PASS(test_NotCont());
   PASS(test_NotFirst());


### PR DESCRIPTION
Reinitialize the device to put the device back to normal state in-case if the channel was closed due to errors.