### PR TITLE
Add backend APIs for issuing U2F requests and processing U2F responses.

### DIFF
--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/endpoints/Constants.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/endpoints/Constants.java
@@ -1,0 +1,17 @@
+package com.google.u2f.gaedemo.endpoints;
+
+public class Constants {
+  // Scopes: https://developers.google.com/identity/protocols/googlescopes
+  public static final String EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email";
+  public static final String OPENID_SCOPE = "openid";
+  
+  // ClientIds:
+  // https://cloud.google.com/appengine/docs/standard/java/endpoints/add-authorization-backend
+  public static final String WEB_CLIENT_ID =
+      "533916084229-qmk7s8pcv7u4uhj2coctv9h75rbp66d3.apps.googleusercontent.com";
+  public static final String ANDROID_CLIENT_ID =
+      "533916084229-a1v1p3l6vhtmo0h5931lc90oo10274da.apps.googleusercontent.com";
+  public static final String ANDROID_AUDIENCE = WEB_CLIENT_ID;
+
+  public static final String APP_ID = "https://u2fdemo.appspot.com/origins.json";
+}

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/endpoints/U2FRequestHandler.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/endpoints/U2FRequestHandler.java
@@ -51,7 +51,6 @@ public class U2FRequestHandler {
   private DataStore dataStore = null;
 
   // https://cloud.google.com/appengine/docs/standard/java/endpoints/annotate-code
-  // https://cloud.google.com/appengine/docs/standard/java/endpoints/parameter-and-return-types
   @ApiMethod(name = "getRegistrationRequest")
   public String[] getRegistrationRequest(
       User user, @Named("allowReregistration") boolean allowReregistration)

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/endpoints/U2FRequestHandler.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/endpoints/U2FRequestHandler.java
@@ -1,0 +1,246 @@
+package com.google.u2f.gaedemo.endpoints;
+
+import com.google.api.server.spi.config.Api;
+import com.google.api.server.spi.config.ApiMethod;
+import com.google.api.server.spi.config.ApiNamespace;
+import com.google.appengine.api.oauth.OAuthRequestException;
+import com.google.appengine.api.users.User;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.u2f.U2FException;
+import com.google.u2f.gaedemo.impl.ChallengeGeneratorImpl;
+import com.google.u2f.gaedemo.impl.DataStoreImpl;
+import com.google.u2f.gaedemo.storage.TokenStorageData;
+import com.google.u2f.server.DataStore;
+import com.google.u2f.server.U2FServer;
+import com.google.u2f.server.data.SecurityKeyData;
+import com.google.u2f.server.impl.BouncyCastleCrypto;
+import com.google.u2f.server.impl.U2FServerReferenceImpl;
+import com.google.u2f.server.messages.RegistrationRequest;
+import com.google.u2f.server.messages.RegistrationResponse;
+import com.google.u2f.server.messages.SignResponse;
+import com.google.u2f.server.messages.U2fSignRequest;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+
+import java.util.List;
+import javax.inject.Named;
+import javax.servlet.ServletException;
+
+@Api(
+  name = "u2fRequestHandler",
+  version = "v1",
+  scopes = {Constants.EMAIL_SCOPE, Constants.OPENID_SCOPE},
+  clientIds = {Constants.WEB_CLIENT_ID, Constants.ANDROID_CLIENT_ID},
+  audiences = {Constants.ANDROID_AUDIENCE},
+  namespace =
+      @ApiNamespace(ownerName = "gaedemo.u2f.google.com", ownerDomain = "gaedemo.u2f.google.com")
+)
+/**
+ * An endpoint class for handling U2F requests.
+ * 
+ * Google Cloud Endpoints generate APIs and client libraries from API backend, to simplify client
+ * access to data from other applications.
+ * https://cloud.google.com/appengine/docs/standard/java/endpoints/
+ */
+public class U2FRequestHandler {
+  private U2FServer u2fServer = null;
+  private DataStore dataStore = null;
+
+  // https://cloud.google.com/appengine/docs/standard/java/endpoints/annotate-code
+  // https://cloud.google.com/appengine/docs/standard/java/endpoints/parameter-and-return-types
+  @ApiMethod(name = "getRegistrationRequest")
+  public String[] getRegistrationRequest(
+      User user, @Named("allowReregistration") boolean allowReregistration)
+      throws OAuthRequestException, ServletException {
+    if (user == null) {
+      throw new OAuthRequestException("user is not authenticated");
+    }
+
+    if (u2fServer == null) {
+      initU2fServer();
+    }
+
+    RegistrationRequest registrationRequest;
+    U2fSignRequest signRequest;
+    try {
+      registrationRequest = u2fServer.getRegistrationRequest(user.getEmail(), Constants.APP_ID);
+      signRequest = u2fServer.getSignRequest(user.getEmail(), Constants.APP_ID);
+    } catch(U2FException e) {
+      throw new ServletException("couldn't get registration request", e);
+    }
+
+    JsonObject result = new JsonObject();
+    result.addProperty("appId", Constants.APP_ID);
+    result.addProperty("sessionId", registrationRequest.getSessionId());
+
+    JsonArray registerRequests = new JsonArray();
+    JsonObject registerRequest = new JsonObject();
+    registerRequest.addProperty("challenge", registrationRequest.getChallenge());
+    registerRequest.addProperty("version", registrationRequest.getVersion());
+    registerRequests.add(registerRequest);
+    result.add("registerRequests", registerRequests);
+
+    if (allowReregistration) {
+      result.add("registeredKeys", new JsonArray());
+    } else {
+      result.add("registeredKeys", signRequest.getRegisteredKeysAsJson(Constants.APP_ID));
+    }
+
+    return new String[] {result.toString()};
+  }
+
+  @ApiMethod(name = "processRegistrationResponse")
+  public String[] processRegistrationResponse(
+      @Named("responseData") String responseData, User user)
+      throws OAuthRequestException, ServletException {
+    if (user == null) {
+      throw new OAuthRequestException("user is not authenticated");
+    }
+
+    JsonObject responseDataJson = (JsonObject) new JsonParser().parse(responseData);
+
+    String currentUser = user.getEmail();
+    String expectedUser = dataStore.getEnrollSessionData(
+        responseDataJson.get("sessionId").toString()).getAccountName();
+    if (!currentUser.equals(expectedUser)) {
+      throw new ServletException("Cross-site request prohibited");
+    }
+
+    RegistrationResponse registrationResponse =
+        new RegistrationResponse(
+            responseDataJson.get("registrationData").toString(),
+            responseDataJson.get("clientData").toString(),
+            responseDataJson.get("sessionId").toString());
+
+    if (u2fServer == null) {
+      initU2fServer();
+    }
+
+    SecurityKeyData securityKeyData;
+
+    try {
+      securityKeyData =
+          u2fServer.processRegistrationResponse(registrationResponse, System.currentTimeMillis());
+    } catch (U2FException e) {
+      throw new ServletException(e);
+    }
+
+    return new String[] {new TokenStorageData(securityKeyData).toJson().toString()};
+  }
+
+  @ApiMethod(name = "getSignRequest", path = "getSignRequest")
+  public String[] getSignRequest(User user) throws OAuthRequestException, ServletException {
+    if (user == null) {
+      throw new OAuthRequestException("user is not authenticated");
+    }
+
+    if (u2fServer == null) {
+      initU2fServer();
+    }
+
+    U2fSignRequest u2fSignRequest;
+    try {
+      u2fSignRequest = u2fServer.getSignRequest(user.getEmail(), Constants.APP_ID);
+    } catch (U2FException e) {
+      throw new ServletException("couldn't get sign request", e);
+    }
+
+    JsonObject result = new JsonObject();
+    result.addProperty("challenge", u2fSignRequest.getChallenge());
+    result.addProperty("appId", Constants.APP_ID);
+    result.add("registeredKeys", u2fSignRequest.getRegisteredKeysAsJson(Constants.APP_ID));
+
+    return new String[] {result.toString()};
+  }
+
+  @ApiMethod(name = "processSignResponse")
+  public String[] processSignResponse(@Named("responseData") String responseData, User user)
+      throws OAuthRequestException, ServletException {
+    if (user == null) {
+      throw new OAuthRequestException("user is not authenticated");
+    }
+
+    JsonObject responseDataJson = (JsonObject) new JsonParser().parse(responseData);
+    String currentUser = user.getEmail();
+    String expectedUser =
+        dataStore.getSignSessionData(responseDataJson.get("sessionId").toString()).getAccountName();
+
+    if (!currentUser.equals(expectedUser)) {
+      throw new ServletException("Cross-site request prohibited");
+    }
+
+    SignResponse signResponse =
+        new SignResponse(
+            responseDataJson.get("keyHandle").toString(),
+            responseDataJson.get("signatureData").toString(),
+            responseDataJson.get("clientData").toString(),
+            responseDataJson.get("sessionId").toString());
+
+    if (u2fServer == null) {
+      initU2fServer();
+    }
+
+    SecurityKeyData securityKeyData;
+    try {
+      securityKeyData = u2fServer.processSignResponse(signResponse);
+    } catch (U2FException e) {
+      throw new ServletException("signature didn't verify", e);
+    }
+
+    return new String[] {new TokenStorageData(securityKeyData).toJson().toString()};
+  }
+
+  @ApiMethod(name = "getAllSecurityKeys", path = "getAllSecurityKeys")
+  public String[] getAllSecurityKeys(User user) throws OAuthRequestException {
+    if (user == null) {
+      throw new OAuthRequestException("user is not authenticated");
+    }
+
+    JsonArray resultList = new JsonArray();
+    if (u2fServer == null) {
+      initU2fServer();
+    }
+
+    List<SecurityKeyData> tokens = u2fServer.getAllSecurityKeys(user.getEmail());
+    for (SecurityKeyData token : tokens) {
+      resultList.add(new TokenStorageData(token).toJson());
+    }
+    return new String[] {resultList.toString()};
+  }
+
+  @ApiMethod(name = "removeSecurityKey")
+  public String[] removeSecurityKey(User user, @Named("publicKey") String publicKey)
+      throws OAuthRequestException, U2FException, DecoderException {
+    if (user == null) {
+      throw new OAuthRequestException("user is not authenticated");
+    }
+
+    if (u2fServer == null) {
+      initU2fServer();
+    }
+
+    u2fServer.removeSecurityKey(user.getEmail(), Hex.decodeHex(publicKey.toCharArray()));
+    return new String[] {"OK"};
+  }
+
+  private void initU2fServer() {
+    if (dataStore == null) {
+      dataStore = new DataStoreImpl();
+    }
+
+    u2fServer =
+        new U2FServerReferenceImpl(
+            new ChallengeGeneratorImpl(),
+            dataStore,
+            new BouncyCastleCrypto(),
+            ImmutableSet.of(
+                // This implementation will only accept signatures from the following origins,
+                // as this class is for generating endpoints APIs for the below Android client app.
+                // This list should always be in sync with the content in Constants.APP_ID.
+                "android:apk-key-hash:bkHnlWEV_jRCPdYGJfwOl7Sn_CLC_2TE3h4TO1_n34I"));
+  }
+}

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginEnrollServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginEnrollServlet.java
@@ -46,8 +46,8 @@ public class BeginEnrollServlet extends HttpServlet {
     String appId = (req.isSecure() ? "https://" : "http://") + req.getHeader("Host");
 
     try {
-      registrationRequest = u2fServer.getRegistrationRequest(user.getUserId(), appId);
-      signRequest = u2fServer.getSignRequest(user.getUserId(), appId);
+      registrationRequest = u2fServer.getRegistrationRequest(user.getEmail(), appId);
+      signRequest = u2fServer.getSignRequest(user.getEmail(), appId);
     } catch (U2FException e) {
       throw new ServletException("couldn't get registration request", e);
     }

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
@@ -43,7 +43,7 @@ public class BeginSignServlet extends HttpServlet {
     try {
       signRequest = u2fServer.getSignRequest(user.getEmail(), appId);
     } catch (U2FException e) {
-      throw new ServletException("couldn't get registration request", e);
+      throw new ServletException("couldn't get sign request", e);
     }
 
     JsonObject result = new JsonObject();

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
@@ -41,7 +41,7 @@ public class BeginSignServlet extends HttpServlet {
     U2fSignRequest signRequest;
     String appId = (req.isSecure() ? "https://" : "http://") + req.getHeader("Host");
     try {
-      signRequest = u2fServer.getSignRequest(user.getUserId(), appId);
+      signRequest = u2fServer.getSignRequest(user.getEmail(), appId);
     } catch (U2FException e) {
       throw new ServletException("couldn't get registration request", e);
     }

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/FinishEnrollServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/FinishEnrollServlet.java
@@ -45,7 +45,7 @@ public class FinishEnrollServlet extends HttpServlet {
     // submitting other people's enrollment data. Here we're just checking
     // that it's the same user that also started the enrollment - you might
     // want to do something more sophisticated.
-    String currentUser = userService.getCurrentUser().getUserId();
+    String currentUser = userService.getCurrentUser().getEmail();
     String expectedUser = dataStore
         .getEnrollSessionData(req.getParameter("sessionId"))
         .getAccountName();

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/FinishSignServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/FinishSignServlet.java
@@ -49,7 +49,7 @@ public class FinishSignServlet extends HttpServlet {
     // submitting other people's enrollment data. Here we're just checking
     // that it's the same user that also started the enrollment - you might
     // want to do something more sophisticated.
-    String currentUser = userService.getCurrentUser().getUserId();
+    String currentUser = userService.getCurrentUser().getEmail();
     String expectedUser = sessionData.getAccountName();
     if (!currentUser.equals(expectedUser)) {
       throw new ServletException("Cross-site request prohibited");

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/GetTokensServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/GetTokensServlet.java
@@ -32,8 +32,8 @@ public class GetTokensServlet extends HttpServlet {
 	public void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
 		User user = userService.getCurrentUser();
 		UserTokens tokens = Objects.firstNonNull(
-				ofy().load().type(UserTokens.class).id(user.getUserId()).now(),
-				new UserTokens(user.getUserId()));
+				ofy().load().type(UserTokens.class).id(user.getEmail()).now(),
+				new UserTokens(user.getEmail()));
 				
 		JsonArray resultList = new JsonArray();
 		

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/RemoveTokenServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/RemoveTokenServlet.java
@@ -42,7 +42,7 @@ public class RemoveTokenServlet extends HttpServlet {
         String publicKey = req.getParameter("public_key");
 
         try {
-          u2fServer.removeSecurityKey(user.getUserId(), Hex.decodeHex(publicKey.toCharArray()));
+          u2fServer.removeSecurityKey(user.getEmail(), Hex.decodeHex(publicKey.toCharArray()));
         } catch (U2FException e) {
           throw new ServletException("couldn't remove U2F token", e);
         } catch (DecoderException e) {

--- a/u2f-gae-demo/war/WEB-INF/web.xml
+++ b/u2f-gae-demo/war/WEB-INF/web.xml
@@ -4,33 +4,35 @@ xmlns="http://java.sun.com/xml/ns/javaee"
 xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
 http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
-	<filter>
-		<filter-name>guiceFilter</filter-name>
-		<filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
-	</filter>
 
-	<filter-mapping>
-		<filter-name>guiceFilter</filter-name>
-		<url-pattern>/*</url-pattern>
-	</filter-mapping>
+    <filter>
+        <filter-name>guiceFilter</filter-name>
+        <filter-class>com.google.inject.servlet.GuiceFilter</filter-class>
+    </filter>
 
-	<listener>
-		<listener-class>com.google.u2f.gaedemo.MyGuiceServletContextListener
-		</listener-class>
-	</listener>
+    <filter-mapping>
+        <filter-name>guiceFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
-	<security-constraint>
+    <listener>
+        <listener-class>com.google.u2f.gaedemo.MyGuiceServletContextListener
+        </listener-class>
+    </listener>
+
+    <security-constraint>
         <web-resource-collection>
             <web-resource-name>static</web-resource-name>
             <url-pattern>/js/*</url-pattern>
             <url-pattern>/css/*</url-pattern>
+            <url-pattern>/origins.json</url-pattern>
         </web-resource-collection>
         <user-data-constraint>
             <transport-guarantee>CONFIDENTIAL</transport-guarantee>
         </user-data-constraint>
     </security-constraint>
 
-	  <security-constraint>
+    <security-constraint>
         <web-resource-collection>
             <web-resource-name>admin</web-resource-name>
             <url-pattern>/admin/*</url-pattern>
@@ -42,7 +44,16 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
             <transport-guarantee>CONFIDENTIAL</transport-guarantee>
         </user-data-constraint>
     </security-constraint>
-		
+
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/_ah/spi/*</url-pattern>
+        </web-resource-collection>
+        <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        </user-data-constraint>
+    </security-constraint>
+
     <security-constraint>
         <web-resource-collection>
             <web-resource-name>all-others</web-resource-name>
@@ -55,4 +66,23 @@ http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
             <transport-guarantee>CONFIDENTIAL</transport-guarantee>
         </user-data-constraint>
     </security-constraint>
+
+    <servlet>
+        <servlet-name>SystemServiceServlet</servlet-name>
+        <servlet-class>com.google.api.server.spi.SystemServiceServlet</servlet-class>
+        <init-param>
+            <param-name>services</param-name>
+            <param-value>
+                com.google.u2f.gaedemo.endpoints.U2FRequestHandler
+            </param-value>
+        </init-param>
+    </servlet>
+
+    <!-- GAE checks for this URL pattern mapping to enable Cloud Endpoints.
+         https://cloud.google.com/appengine/docs/standard/java/endpoints/required_files
+    -->
+    <servlet-mapping>
+        <servlet-name>SystemServiceServlet</servlet-name>
+        <url-pattern>/_ah/spi/*</url-pattern>
+    </servlet-mapping>
 </web-app>

--- a/u2f-gae-demo/war/origins.json
+++ b/u2f-gae-demo/war/origins.json
@@ -1,0 +1,8 @@
+{
+  "trustedFacets" : [{
+    "version": { "major": 1, "minor" : 0 },
+    "ids": [
+      "android:apk-key-hash:bkHnlWEV_jRCPdYGJfwOl7Sn_CLC_2TE3h4TO1_n34I"
+    ]
+  }]
+}

--- a/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
@@ -343,15 +343,23 @@ public class U2FServerReferenceImpl implements U2FServer {
   private static Set<String> canonicalizeOrigins(Set<String> origins) {
     ImmutableSet.Builder<String> result = ImmutableSet.builder();
     for (String origin : origins) {
-      result.add(canonicalizeOrigin(origin));
+      if (origin.startsWith("android:apk-key-hash:")) {
+        result.add(origin);
+      } else {
+        result.add(canonicalizeOrigin(origin));
+      }
     }
     return result.build();
   }
 
-  static String canonicalizeOrigin(String url) {
+  static String canonicalizeOrigin(String origin) {
+    if (origin.startsWith("android:apk-key-hash:")) {
+      return origin;
+    }
+
     URI uri;
     try {
-      uri = new URI(url);
+      uri = new URI(origin);
     } catch (URISyntaxException e) {
       throw new RuntimeException("specified bad origin", e);
     }


### PR DESCRIPTION
Hi @leshi, please review this change!

#151 

Endpoints APIs include:

1. return all registered security keys;
2. issue a registration request;
3. process a registration response;
4. issue a signature request;
5. process a signature response.

Besides adding new APIs, user index in Servlets has been changed from userId to email. The reason is Google Cloud Endpoints is using ID tokens for Android, while ID tokens don't include user ID, so getUserId() always returns null from the authenticated User objects. See [Function User.getUserId() in Cloud endpoint api returns null](http://stackoverflow.com/questions/16171225/function-user-getuserid-in-cloud-endpoint-api-returns-null-for-a-user-object-t).

In order to consistently track registered through Android apps (using Endpoints APIs) and web based requests, we change all user index from original userId to email.
