### PR TITLE
changed attestation check to allow trusted certs

### DIFF
--- a/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
+++ b/u2f-ref-code/java/src/com/google/u2f/server/impl/U2FServerReferenceImpl.java
@@ -150,8 +150,20 @@ public class U2FServerReferenceImpl implements U2FServer {
     byte[] signedBytes = RawMessageCodec.encodeRegistrationSignedBytes(
         appIdSha256, clientDataSha256, keyHandle, userPublicKey);
 
+
+    //check if issuers are trusted
     Set<X509Certificate> trustedCertificates = dataStore.getTrustedCertificates();
-    if (!trustedCertificates.contains(attestationCertificate)) {
+    boolean found = false;
+    for (X509Certificate trusted : trustedCertificates) {
+    	try {
+			  attestationCertificate.verify(trusted.getPublicKey());
+			  found = true;
+		  } catch (InvalidKeyException | CertificateException | NoSuchAlgorithmException | NoSuchProviderException| SignatureException e) {
+
+		  }
+    }
+
+    if (!found) {
       Log.warning("attestion cert is not trusted");
     }
 


### PR DESCRIPTION
Current implementation doesn't work with keys that have a signed attestation cert (like yubico's).  Integrating code from https://github.com/TremoloSecurity/OpenUnison/issues/191