### PR TITLE
Consolidate AppId for web-based and app-based U2F requests.

### DIFF
--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginEnrollServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginEnrollServlet.java
@@ -43,7 +43,8 @@ public class BeginEnrollServlet extends HttpServlet {
     boolean allowReregistration = Boolean.valueOf(req.getParameter("reregistration"));
     RegistrationRequest registrationRequest;
     U2fSignRequest signRequest;
-    String appId = (req.isSecure() ? "https://" : "http://") + req.getHeader("Host");
+    String appId =
+        (req.isSecure() ? "https://" : "http://") + req.getHeader("Host") + "/origins.json";
 
     try {
       registrationRequest = u2fServer.getRegistrationRequest(user.getEmail(), appId);

--- a/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
+++ b/u2f-gae-demo/src/com/google/u2f/gaedemo/servlets/BeginSignServlet.java
@@ -39,7 +39,8 @@ public class BeginSignServlet extends HttpServlet {
     User user = userService.getCurrentUser();
 
     U2fSignRequest signRequest;
-    String appId = (req.isSecure() ? "https://" : "http://") + req.getHeader("Host");
+    String appId =
+        (req.isSecure() ? "https://" : "http://") + req.getHeader("Host") + "/origins.json";
     try {
       signRequest = u2fServer.getSignRequest(user.getEmail(), appId);
     } catch (U2FException e) {

--- a/u2f-gae-demo/war/origins.json
+++ b/u2f-gae-demo/war/origins.json
@@ -2,6 +2,10 @@
   "trustedFacets" : [{
     "version": { "major": 1, "minor" : 0 },
     "ids": [
+      "http://localhost:8888",
+      "https://u2fdemo.appspot.com",
+      "https://crxjs-dot-u2fdemo.appspot.com",
+      "https://noext-dot-u2fdemo.appspot.com",
       "android:apk-key-hash:bkHnlWEV_jRCPdYGJfwOl7Sn_CLC_2TE3h4TO1_n34I"
     ]
   }]


### PR DESCRIPTION
Hi @leshi, please review this change.

Without this, web-based and app-based U2F requests will have different AppIds, and it makes the same token registered under web-based requests can't be recognized by requests in app-based requests, and vice versa.