### PR TITLE
Honor external toolchain environment variables and use hidapi library if available

### DIFF
--- a/u2f-tests/HID/Makefile
+++ b/u2f-tests/HID/Makefile
@@ -6,25 +6,28 @@
 
 all: list HIDTest U2FTest
 
+CC ?= gcc
+CXX ?= g++
+
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
 
-CFLAGS=-Ihidapi/hidapi -D__OS_LINUX -Icore/include
-LDFLAGS=-lrt -ludev
+CPPFLAGS+=-Ihidapi/hidapi -D__OS_LINUX -Icore/include
+LDLIBS+=-lrt -ludev
 HIDAPI=hid.o
 hid.o: hidapi/linux/hid.c
-	gcc -c $(CFLAGS) -o hid.o hidapi/linux/hid.c
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -o hid.o hidapi/linux/hid.c
 
 endif  # Linux
 
 ifeq ($(UNAME), Darwin)
 
-CFLAGS=-Ihidapi/hidapi -Icore/include -D__OS_MAC
-LDFLAGS=-framework IOKit -framework CoreFoundation
+CPPFLAGS+=-Ihidapi/hidapi -Icore/include -D__OS_MAC
+LDLIBS+=-framework IOKit -framework CoreFoundation
 HIDAPI=hid.o
 hid.o: hidapi/mac/hid.c
-	gcc -c $(CFLAGS) -o hid.o hidapi/mac/hid.c
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -o hid.o hidapi/mac/hid.c
 
 endif  # Darwin
 
@@ -32,32 +35,32 @@ endif  # Darwin
 LIBMINCRYPT=dsa_sig.o p256.o p256_ec.o p256_ecdsa.o sha256.o
 
 dsa_sig.o: core/libmincrypt/dsa_sig.c
-	gcc -c $(CFLAGS) -Wall $^
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -Wall $^
 
 p256.o: core/libmincrypt/p256.c
-	gcc -c $(CFLAGS) -Wall $^
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -Wall $^
 
 p256_ec.o: core/libmincrypt/p256_ec.c
-	gcc -c $(CFLAGS) -Wall $^
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -Wall $^
 
 p256_ecdsa.o: core/libmincrypt/p256_ecdsa.c
-	gcc -c $(CFLAGS) -Wall $^
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -Wall $^
 
 sha256.o: core/libmincrypt/sha256.c
-	gcc -c $(CFLAGS) -Wall $^
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -Wall $^
 
 # utility tools.
 u2f_util.o: u2f_util.cc u2f_util.h u2f.h u2f_hid.h
-	g++ -c $(CFLAGS) -Wall -o u2f_util.o u2f_util.cc
+	$(CXX) -c $(CPPFLAGS) $(CFLAGS) -Wall -o u2f_util.o u2f_util.cc
 
 # simple hidapi tool to list devices to see paths.
 list: list.c $(HIDAPI)
-	gcc $(CFLAGS) -Wall -o $@ $^ $(LDFLAGS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -Wall -o $@ $^ $(LDLIBS)
 
 # Low-level HID framing test.
 HIDTest: HIDTest.cc u2f_util.o $(HIDAPI)
-	g++ $(CFLAGS) -Wall -o $@ $^ $(LDFLAGS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -Wall -o $@ $^ $(LDLIBS)
 
 # U2F messaging crypto test.
 U2FTest: U2FTest.cc u2f_util.o $(HIDAPI) $(LIBMINCRYPT)
-	g++ $(CFLAGS) -Wall -o $@ $^ $(LDFLAGS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) -Wall -o $@ $^ $(LDLIBS)

--- a/u2f-tests/HID/Makefile
+++ b/u2f-tests/HID/Makefile
@@ -8,17 +8,29 @@ all: list HIDTest U2FTest
 
 CC ?= gcc
 CXX ?= g++
+PKG_CONFIG ?= pkg-config
 
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
 
-CPPFLAGS+=-Ihidapi/hidapi -D__OS_LINUX -Icore/include
-LDLIBS+=-lrt -ludev
-HIDAPI=hid.o
+HIDAPI_PKG:=hidapi-hidraw
+HIDAPI_LDLIBS:=$(shell $(PKG_CONFIG) --libs $(HIDAPI_PKG))
+ifeq ($(HIDAPI_LDLIBS),)
+# Use local source code
+HIDAPI:=hid.o
+HIDAPI_CPPFLAGS:=-Ihidapi/hidapi
 hid.o: hidapi/linux/hid.c
 	$(CC) -c $(CPPFLAGS) $(CFLAGS) -o hid.o hidapi/linux/hid.c
 
+else
+# Use hidapi library
+HIDAPI:=
+HIDAPI_CPPFLAGS:=$(shell $(PKG_CONFIG) --cflags-only-I $(HIDAPI_PKG))
+endif # hidapi library
+
+CPPFLAGS+=$(HIDAPI_CPPFLAGS) -D__OS_LINUX -Icore/include
+LDLIBS+=-lrt -ludev $(HIDAPI_LDLIBS)
 endif  # Linux
 
 ifeq ($(UNAME), Darwin)


### PR DESCRIPTION
If the compiler/CFLAGS were set in the environment, do not override
them.

Signed-off-by: Vincent Palatin <vpalatin@chromium.org>