### PR TITLE
Request attestation if selected

### DIFF
--- a/u2f-gae-demo/src/soy/main.soy
+++ b/u2f-gae-demo/src/soy/main.soy
@@ -28,7 +28,8 @@
   
   <div id='sidebar'>
     <div id="addToken" style="-webkit-user-select: none;">Register U2F Authenticator</div>
-    <label><input id="reregistration" type="checkbox" />allow re-registration</label> 
+    <label><input id="reregistration" type="checkbox" />allow re-registration</label>
+    <label><input id="req-attestation" type="checkbox" />request attestation</label>
     <div id="testAuth" style="-webkit-user-select: none;">Test Authentication</div>
     <div id="downloadCrx">
       <a href="https://chrome.google.com/webstore/detail/fido-u2f-universal-2nd-fa/pfboblefjcgdjicmnffhdgionmgcdmne">install the Chrome extension</a>

--- a/u2f-gae-demo/war/js/u2fdemo.js
+++ b/u2f-gae-demo/war/js/u2fdemo.js
@@ -157,6 +157,10 @@ function sendBeginEnrollRequest() {
    .done(function(beginEnrollResponse) {
       console.log(beginEnrollResponse);
       showMessage("please touch the token");
+      // Request attestation if needed
+      if (document.getElementById("req-attestation").checked) {
+        beginEnrollResponse.registerRequests.attestation = 'direct';
+      }
       u2f.register(
         beginEnrollResponse.appId,
         [beginEnrollResponse.registerRequests],


### PR DESCRIPTION
As per https://www.chromium.org/security-keys, Chrome is no longer allowing attestations from security keys to be returned by default as part of a U2F request. Attestations can still be requested with an 'attestation' parameter in the Registration Request dictionary.

Adding a checkbox to request attestation during registration requests.