### PR TITLE
Omit zero LC when sending an extended length cAPDU

### DIFF
--- a/u2f-tests/NFC/u2f_nfc_util.c
+++ b/u2f-tests/NFC/u2f_nfc_util.c
@@ -329,13 +329,19 @@ uint xchgAPDUExtended(uint cla, uint ins, uint p1, uint p2, uint lc,
   capdu[INS] = ins & 0xff;
   capdu[P1] = p1 & 0xff;
   capdu[P2] = p2 & 0xff;
-  capdu[4] = 0;
-  capdu[5] = (lc>>8) & 0xff;
-  capdu[6]= lc & 0xff;
-  memcpy((void*)&capdu[7], (const void*)data, lc);
-  capdu[7+lc]=(uint8_t) ((*rapduLen/256) & 0xff);
-  capdu[8+lc]=(uint8_t) (*rapduLen & 0xff);
-  len = lc+9;
+  if (lc != 0) {
+    capdu[4] = 0;
+    capdu[5] = (lc>>8) & 0xff;
+    capdu[6]= lc & 0xff;
+    memcpy((void*)&capdu[7], (const void*)data, lc);
+    capdu[7+lc]=(uint8_t) ((*rapduLen/256) & 0xff);
+    capdu[8+lc]=(uint8_t) (*rapduLen & 0xff);
+    len = lc+9;
+  } else {
+    capdu[4]=(uint8_t) ((*rapduLen/256) & 0xff);
+    capdu[5]=(uint8_t) (*rapduLen & 0xff);
+    len = 6;
+  }
 
   start  = getTimestampMs();
   printCmdAPDU(capdu, len);


### PR DESCRIPTION
The specification of the Extended Length format for cAPDUs mandates that the bytes encoding LC are to be omitted if LC=0. This change fixes the behavior of xchgAPDUExtended in this regard.