### PR TITLE
Migrate hidapi to its new github location

### DIFF
--- a/u2f-tests/HID/README
+++ b/u2f-tests/HID/README
@@ -4,7 +4,7 @@ HIDTest to check compliance at the usb HID communication layer.
 U2FTest to check compliance at the application layer.
 
 DEPENDENCIES:
-git clone https://github.com/signal11/hidapi
+git clone https://github.com/libusb/hidapi
 git clone -b lollipop-release https://android.googlesource.com/platform/system/core
 
 linux: sudo apt-get install libudev-dev


### PR DESCRIPTION
The signal11/hidapi is not being maintained. See https://github.com/signal11/hidapi/issues/373#issuecomment-498836983 for discussion.

This PR updates this repo to the currently maintained version.